### PR TITLE
manejo de alertas y errores

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+## Runox-Game-Engine

--- a/src/commands/command.service.ts
+++ b/src/commands/command.service.ts
@@ -10,6 +10,7 @@ import { FinalizeTurnCommand } from './finalize-turn.command';
 import { YellUnoCommand } from './yell-uno.command';
 import { ICard } from '../models/card.model';
 import { GameModes } from '../models/game-modes';
+import { Observable } from 'rxjs';
 
 /**
  * Class that serves as an entry point for invoking commands within the game
@@ -28,7 +29,7 @@ export class CommandService {
    * @returns observable with the intention of being able to track the success or failure
    * of the command group invocation
    */
-  startGame(currentState: IGameState, gameModes?: GameModes) {
+  startGame(currentState: IGameState, gameModes?: GameModes): Observable<void> {
     const invoker = new CommandsInvoker([
       new BuildDeckCommand(),
       new StartGameCommand(gameModes),
@@ -45,7 +46,7 @@ export class CommandService {
    * @returns observable with the intention of being able to track the success or failure
    * of the command group invocation
    */
-  addPlayers(currentState: IGameState, players: IPlayer[]) {
+  addPlayers(currentState: IGameState, players: IPlayer[]): Observable<void> {
     const invoker = new CommandsInvoker([new AddPlayersCommand(players)]);
 
     return invoker.invoke(currentState);
@@ -66,7 +67,7 @@ export class CommandService {
     playerId: string,
     card: ICard,
     toPlayerId?: string,
-  ) {
+  ): Observable<void> {
     const invoker = new CommandsInvoker([
       new PlayCardCommand(playerId, card, toPlayerId),
       new FinalizeTurnCommand(),
@@ -82,7 +83,7 @@ export class CommandService {
    * @returns observable with the intention of being able to track the success or failure
    * of the command group invocation
    */
-  takeCard(currentState: IGameState) {
+  takeCard(currentState: IGameState): Observable<void> {
     const invoker = new CommandsInvoker([
       new TakeDeckCardCommand(),
       new FinalizeTurnCommand(),
@@ -99,7 +100,7 @@ export class CommandService {
    * @returns observable with the intention of being able to track the success or failure
    * of the command group invocation
    */
-  yellUno(currentState: IGameState, yellerId?: string) {
+  yellUno(currentState: IGameState, yellerId?: string): Observable<void> {
     const invoker = new CommandsInvoker([new YellUnoCommand(yellerId)]);
 
     return invoker.invoke(currentState);

--- a/src/commands/commands-invoker.ts
+++ b/src/commands/commands-invoker.ts
@@ -32,7 +32,8 @@ export class CommandsInvoker {
           const commandValidation = command.validate(currentState);
 
           if (!commandValidation.isValid) {
-            throw new Error(commandValidation.error);
+            subscriber.error(commandValidation.error);
+            return;
           }
 
           command.execute(currentState);

--- a/src/commands/play-card.command.ts
+++ b/src/commands/play-card.command.ts
@@ -7,6 +7,8 @@ import { IPlayer } from '../models/player.model';
 import { ICard, Card } from '../models/card.model';
 import { GameEndEvent } from '../events/game-end.event';
 import { AfterTakeCardsEvent } from '../events/after-take-cards.event';
+import { ReverseEvent } from "../events/reverse.event";
+import { SkipEvent } from "../events/skip.event";
 
 /**
  * Class that allows a player to play a card from his hand
@@ -101,6 +103,9 @@ export class PlayCardCommand extends GameCommand {
 
     if (state.stack.cardOnTop?.value === Value.SKIP) {
       state.turn.setPlayerTurn(state.nextPlayerToPlay);
+      this.events.dispatchSkip(
+        new SkipEvent(state.nextPlayerToPlay)
+      );
     }
 
     if (state.stack.cardOnTop?.value === Value.REVERSE) {
@@ -110,6 +115,9 @@ export class PlayCardCommand extends GameCommand {
         // si son dos jugadores entonces funciona como SKIP
         state.turn.setPlayerTurn(state.nextPlayerToPlay);
       }
+      this.events.dispatchReverse(
+        new ReverseEvent(state.nextPlayerToPlay)
+      );
     }
 
     const player = state.playersGroup.getPlayerById(this.playerId);

--- a/src/events/color-change.event.ts
+++ b/src/events/color-change.event.ts
@@ -1,0 +1,13 @@
+import { Player } from "../models/player.model";
+
+/**
+ * Event that fires when the color of card has changed
+ */
+export class ChangeColorEvent {
+  /**
+   * Event that fires when the color of card has changed
+   *
+   * @param color - new color
+   */
+  constructor(public readonly color: string) {}
+}

--- a/src/events/game-event.enum.ts
+++ b/src/events/game-event.enum.ts
@@ -2,10 +2,14 @@
  * Events that happen during a game match
  */
 export enum GameEvent {
-  AFTER_GAME_START = 'afterGameStart',
-  AFTER_PLAY_CARD = 'afterPlayCard',
-  AFTER_TAKE_CARDS = 'afterTakeCards',
-  AFTER_YELL_UNO = 'afterYellUno',
-  BEFORE_TURN = 'beforeTurn',
-  GAME_END = 'gameEnd',
+  AFTER_GAME_START = "afterGameStart",
+  AFTER_PLAY_CARD = "afterPlayCard",
+  AFTER_TAKE_CARDS = "afterTakeCards",
+  AFTER_YELL_UNO = "afterYellUno",
+  BEFORE_TURN = "beforeTurn",
+  GAME_END = "gameEnd",
+  CHANGE_COLOR = "changeColor",
+  REVERSE = "reverse",
+  SKIP = "skip",
+  ERROR = "error",
 }

--- a/src/events/game-events.ts
+++ b/src/events/game-events.ts
@@ -1,13 +1,13 @@
-import { Subject } from "rxjs";
-import { GameEvent } from "./game-event.enum";
-import { AfterPlayCardEvent } from "./after-play-card.event";
-import { AfterTakeCardsEvent } from "./after-take-cards.event";
-import { BeforeTurnEvent } from "./before-turn.event";
-import { GameEndEvent } from "./game-end.event";
-import { AfterYellUnoEvent } from "./after-yell-uno.event";
-import { ChangeColorEvent } from "./color-change.event";
-import { SkipEvent } from "./skip.event";
-import { ReverseEvent } from "./reverse.event";
+import { Subject } from 'rxjs';
+import { GameEvent } from './game-event.enum';
+import { AfterPlayCardEvent } from './after-play-card.event';
+import { AfterTakeCardsEvent } from './after-take-cards.event';
+import { BeforeTurnEvent } from './before-turn.event';
+import { GameEndEvent } from './game-end.event';
+import { AfterYellUnoEvent } from './after-yell-uno.event';
+import { ChangeColorEvent } from './color-change.event';
+import { SkipEvent } from './skip.event';
+import { ReverseEvent } from './reverse.event';
 
 /**
  * Game event utility class
@@ -89,7 +89,6 @@ export class GameEvents {
   get changeColor$() {
     return this.events[GameEvent.CHANGE_COLOR].asObservable();
   }
-
 
   /**
    * Observable that emits values when the color of card has changed
@@ -181,7 +180,6 @@ export class GameEvents {
   dispatchSkip(data: SkipEvent) {
     return this.events[GameEvent.SKIP].next(data);
   }
-  
 
   /**
    * Emits value the direction is changed by revert card
@@ -193,7 +191,7 @@ export class GameEvents {
   }
 
   /**
-   * Emits error 
+   * Emits error
    *
    * @param error
    */

--- a/src/events/game-events.ts
+++ b/src/events/game-events.ts
@@ -1,10 +1,13 @@
-import { Subject } from 'rxjs';
-import { GameEvent } from './game-event.enum';
-import { AfterPlayCardEvent } from './after-play-card.event';
-import { AfterTakeCardsEvent } from './after-take-cards.event';
-import { BeforeTurnEvent } from './before-turn.event';
-import { GameEndEvent } from './game-end.event';
-import { AfterYellUnoEvent } from './after-yell-uno.event';
+import { Subject } from "rxjs";
+import { GameEvent } from "./game-event.enum";
+import { AfterPlayCardEvent } from "./after-play-card.event";
+import { AfterTakeCardsEvent } from "./after-take-cards.event";
+import { BeforeTurnEvent } from "./before-turn.event";
+import { GameEndEvent } from "./game-end.event";
+import { AfterYellUnoEvent } from "./after-yell-uno.event";
+import { ChangeColorEvent } from "./color-change.event";
+import { SkipEvent } from "./skip.event";
+import { ReverseEvent } from "./reverse.event";
 
 /**
  * Game event utility class
@@ -19,6 +22,10 @@ export class GameEvents {
     [GameEvent.AFTER_YELL_UNO]: new Subject<AfterYellUnoEvent>(),
     [GameEvent.BEFORE_TURN]: new Subject<BeforeTurnEvent>(),
     [GameEvent.GAME_END]: new Subject<GameEndEvent>(),
+    [GameEvent.CHANGE_COLOR]: new Subject<ChangeColorEvent>(),
+    [GameEvent.SKIP]: new Subject<SkipEvent>(),
+    [GameEvent.REVERSE]: new Subject<ReverseEvent>(),
+    [GameEvent.ERROR]: new Subject<any>(),
   };
 
   private constructor() {}
@@ -38,49 +45,78 @@ export class GameEvents {
    * Observable that emits values when the game starts
    */
   get afterGameStart$() {
-    return this.events.afterGameStart.asObservable();
+    return this.events[GameEvent.AFTER_GAME_START].asObservable();
   }
 
   /**
    * Observable that emits values after a card is played
    */
   get afterPlayCard$() {
-    return this.events.afterPlayCard.asObservable();
+    return this.events[GameEvent.AFTER_PLAY_CARD].asObservable();
   }
 
   /**
    * Observable that emits values after a card is taken
    */
   get afterTakeCards$() {
-    return this.events.afterTakeCards.asObservable();
+    return this.events[GameEvent.AFTER_TAKE_CARDS].asObservable();
   }
 
   /**
    * Observable that emits values after Uno is yelled
    */
   get afterYellUno$() {
-    return this.events.afterYellUno.asObservable();
+    return this.events[GameEvent.AFTER_YELL_UNO].asObservable();
   }
 
   /**
    * Observable that emits values before a turn begins
    */
   get beforeTurn$() {
-    return this.events.beforeTurn.asObservable();
+    return this.events[GameEvent.BEFORE_TURN].asObservable();
   }
 
   /**
    * Observable that emits values when the game ends
    */
   get gameEnd$() {
-    return this.events.gameEnd.asObservable();
+    return this.events[GameEvent.GAME_END].asObservable();
+  }
+
+  /**
+   * Observable that emits values when the color of card has changed
+   */
+  get changeColor$() {
+    return this.events[GameEvent.CHANGE_COLOR].asObservable();
+  }
+
+
+  /**
+   * Observable that emits values when the color of card has changed
+   */
+  get skip$() {
+    return this.events[GameEvent.SKIP].asObservable();
+  }
+
+  /**
+   * Observable that emits values when the color of card has changed
+   */
+  get reverse$() {
+    return this.events[GameEvent.REVERSE].asObservable();
+  }
+
+  /**
+   * Observable that emits values when an error occurred
+   */
+  get error$() {
+    return this.events[GameEvent.ERROR].asObservable();
   }
 
   /**
    * Emits value in the observable at the beginning of the game
    */
   dispatchAfterGameStart() {
-    return this.events.afterGameStart.next();
+    return this.events[GameEvent.AFTER_GAME_START].next();
   }
 
   /**
@@ -89,7 +125,7 @@ export class GameEvents {
    * @param data contains player information and played card
    */
   dispatchAfterPlayCard(data: AfterPlayCardEvent) {
-    return this.events.afterPlayCard.next(data);
+    return this.events[GameEvent.AFTER_PLAY_CARD].next(data);
   }
 
   /**
@@ -98,7 +134,7 @@ export class GameEvents {
    * @param data contains player information and taken cards
    */
   dispatchAfterTakeCards(data: AfterTakeCardsEvent) {
-    return this.events.afterTakeCards.next(data);
+    return this.events[GameEvent.AFTER_TAKE_CARDS].next(data);
   }
 
   /**
@@ -107,7 +143,7 @@ export class GameEvents {
    * @param data contains yeller information
    */
   dispatchAfterYellUno(data: AfterYellUnoEvent) {
-    return this.events.afterYellUno.next(data);
+    return this.events[GameEvent.AFTER_YELL_UNO].next(data);
   }
 
   /**
@@ -116,7 +152,7 @@ export class GameEvents {
    * @param data contains player information
    */
   dispatchBeforeTurn(data: BeforeTurnEvent) {
-    return this.events.beforeTurn.next(data);
+    return this.events[GameEvent.BEFORE_TURN].next(data);
   }
 
   /**
@@ -125,6 +161,43 @@ export class GameEvents {
    * @param data contains winner information and winner score
    */
   dispatchGameEnd(data: GameEndEvent) {
-    return this.events.gameEnd.next(data);
+    return this.events[GameEvent.GAME_END].next(data);
+  }
+
+  /**
+   * Emits value when the color of card has changed
+   *
+   * @param data contains new color
+   */
+  dispatchChangeColor(data: ChangeColorEvent) {
+    return this.events[GameEvent.CHANGE_COLOR].next(data);
+  }
+
+  /**
+   * Emits value  when the next player has skiped
+   *
+   * @param data contains next user
+   */
+  dispatchSkip(data: SkipEvent) {
+    return this.events[GameEvent.SKIP].next(data);
+  }
+  
+
+  /**
+   * Emits value the direction is changed by revert card
+   *
+   * @param data contains new color
+   */
+  dispatchReverse(data: ReverseEvent) {
+    return this.events[GameEvent.REVERSE].next(data);
+  }
+
+  /**
+   * Emits error 
+   *
+   * @param error
+   */
+  dispatchError(error: any): any {
+    return this.events[GameEvent.ERROR].next(error);
   }
 }

--- a/src/events/reverse.event.ts
+++ b/src/events/reverse.event.ts
@@ -1,0 +1,13 @@
+import { Player } from "../models/player.model";
+
+/**
+ * Event that fires when the direction is changed by revert card
+ */
+export class ReverseEvent {
+  /**
+   * Event that fires when the direction is changed by revert card
+   *
+   * @param player Next player
+   */
+  constructor(public readonly player: Player) {}
+}

--- a/src/events/skip.event.ts
+++ b/src/events/skip.event.ts
@@ -1,0 +1,13 @@
+import { Player } from "../models/player.model";
+
+/**
+ * Event that fires when the next player has skiped
+ */
+export class SkipEvent {
+  /**
+   * Event that fires when the next player has skiped
+   *
+   * @param player Next player
+   */
+  constructor(public readonly player: Player) {}
+}


### PR DESCRIPTION
@jorgeucano @facurodriguez Lo probé utilizando la UI en el otro repo. De todas formas los test corrieron en verde

Agregré una subscripción a los "errores" (mensajes del tipo "La carta que quiere tirar no tiene el mismo color o valor que la del stack") Son flujos normales, no errores del sistema.

Agregué la subscripción para observar cuándo se saltea un usuario y cuando cambia el sentido de la vuelta.

En un futuro agregar un observer para tener un log de las acciones hechas por los usuarios (por ahora no está hecho porque mostraría las cartas ocultas)